### PR TITLE
Require Node.js 22 or newer

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "main": "src/index.ts",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "build": "tsc",
     "clean": "rm -rf dist",


### PR DESCRIPTION
## Summary
- declare Node.js 22 as the minimum supported runtime
- align the template with the oldest currently supported Node.js major

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm lint`