### PR TITLE
chore: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary

- add weekly Dependabot updates for the root pnpm dependency set
- add weekly Dependabot updates for GitHub Actions

## Validation

- [x] Parsed `.github/dependabot.yml` with Ruby YAML
- [x] Ran `git diff --check`
- [x] Confirmed the PR only adds `.github/dependabot.yml`